### PR TITLE
Fix operation with matplotlib >= 1.5.0

### DIFF
--- a/src/OpenWave-1KB.py
+++ b/src/OpenWave-1KB.py
@@ -45,7 +45,7 @@ import matplotlib as mpl
 mpl.rcParams['backend.qt4'] = 'PySide'  #Used for PySide.
 mpl.rcParams['agg.path.chunksize'] = 100000 #For big data.
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
 from mpl_toolkits.axes_grid1 import host_subplot
 import mpl_toolkits.axisartist as AA
 from PySide import QtCore, QtGui


### PR DESCRIPTION
The NavigationToolbar2QTAgg was deprecated in matplotlib 1.4, and
removed in 1.5.0. The [changelog][1] says:

> Remove NavigationToolbar2QTAgg
>
> Added no functionality over the base NavigationToolbar2Qt

Which suggests that just using the base class directly is ok, also for
older versions.

[1]: https://matplotlib.org/api/api_changes.html#remove-navigationtoolbar2qtagg